### PR TITLE
ci: fix release steps

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,12 +20,6 @@ jobs:
           default-branch: main
           signoff: "OpenFeature Bot <109696520+openfeaturebot@users.noreply.github.com>"
 
-      - name: Dump Release Please Output
-        env:
-          RELEASE_PLEASE_OUTPUT: ${{ toJson(steps.release.outputs) }}
-        run: |
-          echo "$RELEASE_PLEASE_OUTPUT"
-
     outputs:
       all: ${{ toJSON(steps.release.outputs) }}
       paths_released: ${{ steps.release.outputs.paths_released }}
@@ -48,12 +42,23 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           ref: ${{ env.TAG }}
-      
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          # TODO see if the ruby version matter for publishing
-          # ruby-version: ${{ matrix.ruby-version }}
+          ruby-version: 3.3
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      ## TODO add a step to publish the gem
+      - name: Release Gem
+        run: |
+          gem install bundler
+          bundle config unset deployment
+          bundle install
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${RUBY_GEM_API_TOKEN}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          RUBY_GEM_API_TOKEN: "${{secrets.RUBY_GEM_API_TOKEN}}"


### PR DESCRIPTION
## This PR

- Updates the release please step to hardcode the current minor of Ruby and add releasing. We need to add the RUBY_GEM_API_TOKEN secret here that we use for the primary SDK gem.
