### PR TITLE
fix: Fractional evaluation

### DIFF
--- a/providers/openfeature-flagd-provider/lib/openfeature/flagd/provider/client.rb
+++ b/providers/openfeature-flagd-provider/lib/openfeature/flagd/provider/client.rb
@@ -98,7 +98,7 @@ module OpenFeature
           return nil unless evaluation_context
 
           fields = evaluation_context.fields
-          fields["targetingKey"] = fields.delete(:targeting_key)
+          fields["targetingKey"] = fields.delete("targeting_key")
           Google::Protobuf::Struct.from_hash(fields)
         end
 

--- a/providers/openfeature-flagd-provider/spec/openfeature/flagd/provider/client_spec.rb
+++ b/providers/openfeature-flagd-provider/spec/openfeature/flagd/provider/client_spec.rb
@@ -92,4 +92,26 @@ RSpec.describe OpenFeature::Flagd::Provider::Client do
       )
     end
   end
+
+  context "EvaluationContext transformation" do
+    subject { client.send(:prepare_evaluation_context, evaluation_context) }
+    let(:evaluation_context) { OpenFeature::SDK::EvaluationContext.new(**fields) }
+
+    context "No context" do
+      let(:evaluation_context) { nil }
+
+      it do
+        expect(subject).to be nil
+      end
+    end
+
+    context "targeting_key transformation to targetingKey" do
+      let(:fields) { {targeting_key: "example"} }
+      let(:expected) { Google::Protobuf::Struct.from_hash({targetingKey: "example"}.transform_keys(&:to_s)) }
+
+      it do
+        expect(subject).to eq(expected)
+      end
+    end
+  end
 end

--- a/providers/openfeature-flagd-provider/spec/openfeature/flagd/provider_spec.rb
+++ b/providers/openfeature-flagd-provider/spec/openfeature/flagd/provider_spec.rb
@@ -123,17 +123,17 @@ RSpec.describe OpenFeature::Flagd::Provider do
 
       it do
         fetch_value_with_targeting_key = ->(targeting_key) do
-          client.fetch_boolean_value(
+          client.fetch_string_value(
             flag_key: "color-palette-experiment",
             default_value: "#b91c1c",
             evaluation_context: OpenFeature::SDK::EvaluationContext.new(targeting_key: targeting_key)
           )
         end
 
-        initial_value = fetch_value_with_targeting_key.call("123")
-        (0..2).to_a.each do # try with 1000
-          expect(fetch_value_with_targeting_key.call("123")).to eq(initial_value)
-        end
+        expect(fetch_value_with_targeting_key.call("1234")).to eq("#b91c1c")
+        expect(fetch_value_with_targeting_key.call("qwe")).to eq("#0284c7")
+        expect(fetch_value_with_targeting_key.call("abcd")).to eq("#16a34a")
+        expect(fetch_value_with_targeting_key.call("rfv")).to eq("#b91c1c")
       end
     end
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Fixes issues with fractional evaluation (when targeting_key is provided). It always resulted in error.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

[Fixes #40](https://github.com/open-feature/ruby-sdk-contrib/issues/40)

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

