### PR TITLE
feat(go-feature-flag): Support exporter metadata

### DIFF
--- a/providers/openfeature-go-feature-flag-provider/lib/openfeature/go-feature-flag/go_feature_flag_provider.rb
+++ b/providers/openfeature-go-feature-flag-provider/lib/openfeature/go-feature-flag/go_feature_flag_provider.rb
@@ -35,6 +35,11 @@ module OpenFeature
         evaluation_context = OpenFeature::SDK::EvaluationContext.new if evaluation_context.nil?
         validate_parameters(flag_key, evaluation_context)
 
+        # enrich the evaluation context with the exporter_metadata
+        @options.exporter_metadata ||= {}
+        @options.exporter_metadata.merge!({"openfeature" => true, "provider" => "ruby"})
+        evaluation_context.fields["gofeatureflag"] = {"exporterMetadata" => @options.exporter_metadata}
+
         # do a http call to the go feature flag server
         parsed_response = @goff_api.evaluate_ofrep_api(flag_key: flag_key, evaluation_context: evaluation_context)
         parsed_response = OfrepApiResponse unless parsed_response.is_a?(OfrepApiResponse)

--- a/providers/openfeature-go-feature-flag-provider/lib/openfeature/go-feature-flag/go_feature_flag_provider.rb
+++ b/providers/openfeature-go-feature-flag-provider/lib/openfeature/go-feature-flag/go_feature_flag_provider.rb
@@ -36,8 +36,7 @@ module OpenFeature
         validate_parameters(flag_key, evaluation_context)
 
         # enrich the evaluation context with the exporter_metadata
-        @options.exporter_metadata ||= {}
-        @options.exporter_metadata.merge!({"openfeature" => true, "provider" => "ruby"})
+        @options.exporter_metadata.merge!("openfeature" => true, "provider" => "ruby")
         evaluation_context.fields["gofeatureflag"] = {"exporterMetadata" => @options.exporter_metadata}
 
         # do a http call to the go feature flag server

--- a/providers/openfeature-go-feature-flag-provider/lib/openfeature/go-feature-flag/options.rb
+++ b/providers/openfeature-go-feature-flag-provider/lib/openfeature/go-feature-flag/options.rb
@@ -8,7 +8,7 @@ module OpenFeature
     class Options
       attr_accessor :endpoint, :custom_headers, :exporter_metadata
 
-      def initialize(endpoint: nil, headers: {}, exporter_metadata: nil)
+      def initialize(endpoint: nil, headers: {}, exporter_metadata: {})
         validate_endpoint(endpoint: endpoint)
         @endpoint = endpoint
         @custom_headers = headers

--- a/providers/openfeature-go-feature-flag-provider/lib/openfeature/go-feature-flag/options.rb
+++ b/providers/openfeature-go-feature-flag-provider/lib/openfeature/go-feature-flag/options.rb
@@ -6,12 +6,13 @@ module OpenFeature
   module GoFeatureFlag
     # This class is the configuration class for the GoFeatureFlagProvider
     class Options
-      attr_accessor :endpoint, :custom_headers
+      attr_accessor :endpoint, :custom_headers, :exporter_metadata
 
-      def initialize(endpoint: nil, headers: {})
+      def initialize(endpoint: nil, headers: {}, exporter_metadata: nil)
         validate_endpoint(endpoint: endpoint)
         @endpoint = endpoint
         @custom_headers = headers
+        @exporter_metadata = exporter_metadata
       end
 
       private


### PR DESCRIPTION
## This PR
In this PR we support `exporterMetadata` that will allow to add static information that will be added to your feature event sent to the GO Feature Flag exporter.

In this PR we add those exporter metadata to the evaluation context in order to pass them to GO Feature Flag relay-proxy.


### Related Issues
https://github.com/thomaspoignant/go-feature-flag/pull/2983

