### PR TITLE
build(meta-provider): Support non-breaking versions of openfeature-sdk

### DIFF
--- a/providers/openfeature-meta_provider/Gemfile.lock
+++ b/providers/openfeature-meta_provider/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     openfeature-meta_provider (0.0.3)
-      openfeature-sdk (~> 0.3.0)
+      openfeature-sdk (>= 0.3.0, <= 0.4)
 
 GEM
   remote: https://rubygems.org/

--- a/providers/openfeature-meta_provider/openfeature-meta_provider.gemspec
+++ b/providers/openfeature-meta_provider/openfeature-meta_provider.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "openfeature-sdk", "~> 0.3.0"
+  spec.add_dependency "openfeature-sdk", ">= 0.3.0", "<= 0.4"
 
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.12"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
The meta provider's gemspec stated only v0.3.x could be used. Unfortunately, this conflicts with the official LaunchDarkly provider, which uses version 0.4.0, preventing this gem from being used along with it.

Although technically speaking openfeature-sdk 0.3.0 -> 0.4.0 is a breaking change because of the change of string values, but it should not cause a problem. This is because the provider uses only the constants rather than the string values themselves, so this should not break the provider.

### Notes
I put <= 0.4 as the maximum version of the SDK, but this can be changed if ya'll think it should be a different value.

### How to test

Import this branch into an application along with the the gem built from https://github.com/launchdarkly/openfeature-ruby-server and verify that using it within a meta-provider works correctly.