### PR TITLE
fix: don't init if provider doesn't have an init method

### DIFF
--- a/providers/openfeature-meta_provider/lib/openfeature/meta_provider.rb
+++ b/providers/openfeature-meta_provider/lib/openfeature/meta_provider.rb
@@ -16,7 +16,7 @@ module OpenFeature
     end
 
     def init
-      providers.each { |provider| provider.init }
+      providers.each { |provider| provider.init if provider.respond_to?(:init) }
     end
 
     def shutdown


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Meta Provider will no longer call `init` if any of the sub-providers do not have an init method

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->


### Notes
<!-- any additional notes for this PR -->

This was blowing up for us because [one of our providers](https://github.com/bdchauvette/flagsmith-openfeature-provider-ruby) does not have an `init` method. Since `init` is common but [not required per OpenFeature spec](https://openfeature.dev/specification/sections/providers#24-initialization) for providers, a simple `responds_to?` check makes this safe for all providers.    

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->
Create a MetaProvider using a provider that does not have an `init` method, such as [this one](https://github.com/bdchauvette/flagsmith-openfeature-provider-ruby), along with a provider that does have an `init` function. Call `init` on the MetaProvider. Assert that `init` was not called on the provider without an `init` method, and that it was called on the provider with an `init` method. 
