### PR TITLE
fix: Set flipt provider version to 0.0.2

### DIFF
--- a/providers/openfeature-flipt-provider/lib/openfeature/flipt/version.rb
+++ b/providers/openfeature-flipt-provider/lib/openfeature/flipt/version.rb
@@ -2,6 +2,6 @@
 
 module OpenFeature
   module Flipt
-    VERSION = "0.1.0"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- To fix failing CI on [this PR](https://github.com/open-feature/ruby-sdk-contrib/pull/54)

### Related Issues

- [Failing CI](https://github.com/open-feature/ruby-sdk-contrib/actions/runs/14469316882/job/40579004475?pr=54)

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks

- Make sure the CI is passed

### How to test
<!-- if applicable, add testing instructions under this section -->

