### PR TITLE
fix(flagd-provider): update fractional targeting test expectations for flagd v0.15.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -181,10 +181,12 @@ jobs:
 
   test_otel_hook:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.ruby-version == 'head' }}
     defaults:
       run:
         working-directory: ./hooks/openfeature-otel-hook
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - "3.4"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -181,7 +181,6 @@ jobs:
 
   test_otel_hook:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.ruby-version == 'head' }}
     defaults:
       run:
         working-directory: ./hooks/openfeature-otel-hook
@@ -197,6 +196,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          bundler: latest
           bundler-cache: true
           working-directory: ./hooks/openfeature-otel-hook
       - name: Check linting

--- a/hooks/openfeature-otel-hook/Gemfile.lock
+++ b/hooks/openfeature-otel-hook/Gemfile.lock
@@ -123,4 +123,4 @@ DEPENDENCIES
   standard (~> 1.0)
 
 BUNDLED WITH
-   4.0.11
+   4.0.12

--- a/hooks/openfeature-otel-hook/Gemfile.lock
+++ b/hooks/openfeature-otel-hook/Gemfile.lock
@@ -123,4 +123,4 @@ DEPENDENCIES
   standard (~> 1.0)
 
 BUNDLED WITH
-   2.7.1
+   4.0.11

--- a/providers/openfeature-flagd-provider/spec/openfeature/flagd/provider_spec.rb
+++ b/providers/openfeature-flagd-provider/spec/openfeature/flagd/provider_spec.rb
@@ -172,10 +172,10 @@ RSpec.describe OpenFeature::Flagd::Provider do
           )
         end
 
-        expect(fetch_value_with_targeting_key.call("1234")).to eq("#b91c1c")
-        expect(fetch_value_with_targeting_key.call("qwe")).to eq("#0284c7")
-        expect(fetch_value_with_targeting_key.call("abcd")).to eq("#16a34a")
-        expect(fetch_value_with_targeting_key.call("rfv")).to eq("#b91c1c")
+        expect(fetch_value_with_targeting_key.call("1234")).to eq("#4b5563")
+        expect(fetch_value_with_targeting_key.call("qwe")).to eq("#4b5563")
+        expect(fetch_value_with_targeting_key.call("abcd")).to eq("#0284c7")
+        expect(fetch_value_with_targeting_key.call("rfv")).to eq("#4b5563")
       end
     end
 

--- a/providers/openfeature-flagd-provider/spec/openfeature/flagd/provider_spec.rb
+++ b/providers/openfeature-flagd-provider/spec/openfeature/flagd/provider_spec.rb
@@ -172,10 +172,10 @@ RSpec.describe OpenFeature::Flagd::Provider do
           )
         end
 
-        expect(fetch_value_with_targeting_key.call("1234")).to eq("#4b5563")
-        expect(fetch_value_with_targeting_key.call("qwe")).to eq("#4b5563")
-        expect(fetch_value_with_targeting_key.call("abcd")).to eq("#0284c7")
-        expect(fetch_value_with_targeting_key.call("rfv")).to eq("#4b5563")
+        expect(fetch_value_with_targeting_key.call("alice")).to eq("#b91c1c")
+        expect(fetch_value_with_targeting_key.call("bob")).to eq("#0284c7")
+        expect(fetch_value_with_targeting_key.call("charlie")).to eq("#16a34a")
+        expect(fetch_value_with_targeting_key.call("dave")).to eq("#4b5563")
       end
     end
 


### PR DESCRIPTION
## Summary

- Updates `color-palette-experiment` fractional targeting test expectations to match bucketing behavior in flagd `v0.15.4`
- The fractional evaluator changed to high-precision integer arithmetic (`(hash * totalWeight) >> 32`), which rebucketed all users — tracked in #73
- Expected values verified by running the exact `twmb/murmur3` + `distributeValue` algorithm from flagd's source at `core/v0.15.4`
- Replaced targeting keys with ones that resolve to all four distinct variants (red, blue, green, grey), so the test validates fractional bucketing rather than falling through to the default
- Originally identified as a pre-existing failure in #165

Also bumps `BUNDLED WITH` in the otel-hook `Gemfile.lock` from 2.7.1 to 4.0.11. A Ruby 4.1dev commit (between May 4–12) made `Pathname::SEPARATOR_PAT` private, breaking bundler 2.7.1's vendored thor. Bundler 4.0.0+ includes the fix (ruby/rubygems#9056).