### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/hooks/openfeature-otel-hook/Gemfile.lock
+++ b/hooks/openfeature-otel-hook/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     bigdecimal (4.1.0)
     diff-lcs (1.6.2)
     docile (1.4.1)
-    json (2.19.1)
+    json (2.21.1)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)

--- a/providers/openfeature-flagd-provider/Gemfile.lock
+++ b/providers/openfeature-flagd-provider/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     grpc (1.78.1-x86_64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    json (2.19.2)
+    json (2.21.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     openfeature-sdk (0.3.1)

--- a/providers/openfeature-flagsmith-provider/Gemfile.lock
+++ b/providers/openfeature-flagsmith-provider/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     bigdecimal (4.0.1)
@@ -17,11 +17,11 @@ GEM
       rexml
     diff-lcs (1.6.2)
     docile (1.4.1)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)

--- a/providers/openfeature-flagsmith-provider/Gemfile.lock
+++ b/providers/openfeature-flagsmith-provider/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
       rexml
     diff-lcs (1.6.2)
     docile (1.4.1)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger

--- a/providers/openfeature-flagsmith-provider/Gemfile.lock
+++ b/providers/openfeature-flagsmith-provider/Gemfile.lock
@@ -16,7 +16,6 @@ GEM
       bigdecimal
       rexml
     diff-lcs (1.6.2)
-    docile (1.4.1)
     faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -81,12 +80,7 @@ GEM
       rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
     semantic (1.6.1)
-    simplecov (0.22.0)
-      docile (~> 1.1)
-      simplecov-html (~> 0.11)
-      simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.13.2)
-    simplecov_json_formatter (0.1.4)
+    simplecov (1.0.2)
     standard (1.55.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -118,7 +112,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.13.0)
   rubocop (~> 1.0)
-  simplecov (~> 0.22)
+  simplecov (~> 1.0)
   standard (~> 1.0)
   webmock (~> 3.0)
 

--- a/providers/openfeature-flagsmith-provider/openfeature-flagsmith-provider.gemspec
+++ b/providers/openfeature-flagsmith-provider/openfeature-flagsmith-provider.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 3.0"
   spec.add_development_dependency "standard", "~> 1.0"
   spec.add_development_dependency "rubocop", "~> 1.0"
-  spec.add_development_dependency "simplecov", "~> 0.22"
+  spec.add_development_dependency "simplecov", "~> 1.0"
 end

--- a/providers/openfeature-flipt-provider/Gemfile.lock
+++ b/providers/openfeature-flipt-provider/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     ffi (1.17.3-x86_64-linux-gnu)
     ffi (1.17.3-x86_64-linux-musl)
     flipt_client (0.10.0)
-    json (2.19.2)
+    json (2.21.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     openfeature-sdk (0.4.0)

--- a/providers/openfeature-go-feature-flag-provider/Gemfile.lock
+++ b/providers/openfeature-go-feature-flag-provider/Gemfile.lock
@@ -8,8 +8,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     bigdecimal (3.1.8)
     connection_pool (2.5.3)
@@ -18,17 +18,17 @@ GEM
       rexml
     diff-lcs (1.5.1)
     docile (1.4.1)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     faraday-net_http_persistent (2.3.1)
       faraday (~> 2.5)
       net-http-persistent (>= 4.0.4, < 5)
     hashdiff (1.1.1)
-    json (2.19.2)
+    json (2.19.7)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -42,7 +42,7 @@ GEM
       ast (~> 2.4.1)
       racc
     prism (1.9.0)
-    public_suffix (6.0.1)
+    public_suffix (7.0.5)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)

--- a/providers/openfeature-go-feature-flag-provider/Gemfile.lock
+++ b/providers/openfeature-go-feature-flag-provider/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       rexml
     diff-lcs (1.5.1)
     docile (1.4.1)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger

--- a/providers/openfeature-go-feature-flag-provider/Gemfile.lock
+++ b/providers/openfeature-go-feature-flag-provider/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       faraday (~> 2.5)
       net-http-persistent (>= 4.0.4, < 5)
     hashdiff (1.1.1)
-    json (2.19.7)
+    json (2.21.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)

--- a/providers/openfeature-meta_provider/Gemfile.lock
+++ b/providers/openfeature-meta_provider/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     irb (1.12.0)
       rdoc
       reline (>= 0.4.2)
-    json (2.19.0)
+    json (2.19.7)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     openfeature-sdk (0.6.4)

--- a/providers/openfeature-meta_provider/Gemfile.lock
+++ b/providers/openfeature-meta_provider/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     irb (1.12.0)
       rdoc
       reline (>= 0.4.2)
-    json (2.19.7)
+    json (2.21.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     openfeature-sdk (0.6.4)

--- a/providers/openfeature-ofrep-provider/Gemfile.lock
+++ b/providers/openfeature-ofrep-provider/Gemfile.lock
@@ -18,17 +18,17 @@ GEM
       rexml
     diff-lcs (1.6.2)
     docile (1.4.1)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     faraday-net_http_persistent (2.3.1)
       faraday (~> 2.5)
       net-http-persistent (>= 4.0.4, < 5)
     hashdiff (1.2.1)
-    json (2.19.0)
+    json (2.19.7)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -129,11 +129,11 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
-  faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
-  faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
+  faraday (2.14.2) sha256=73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad
+  faraday-net_http (3.4.3) sha256=9db13becec9312f345a769eeeecf9049c9287d54c0ae053d7235228993a4eec1
   faraday-net_http_persistent (2.3.1) sha256=23ffba37d6a27807a10f033d01918ec958aa73fa6ff0fccfbcd5ce2d2e68fca3
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  json (2.19.0) sha256=bc5202f083618b3af7aba3184146ec9d820f8f6de261838b577173475e499d9a
+  json (2.19.7) sha256=fe432c8639f6efff69f9d73b518a3705d9581ab93156f981ea72806e1e5bcc3e
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203

--- a/providers/openfeature-ofrep-provider/Gemfile.lock
+++ b/providers/openfeature-ofrep-provider/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       rexml
     diff-lcs (1.6.2)
     docile (1.4.1)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -129,7 +129,7 @@ CHECKSUMS
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
-  faraday (2.14.2) sha256=73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad
+  faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-net_http (3.4.3) sha256=9db13becec9312f345a769eeeecf9049c9287d54c0ae053d7235228993a4eec1
   faraday-net_http_persistent (2.3.1) sha256=23ffba37d6a27807a10f033d01918ec958aa73fa6ff0fccfbcd5ce2d2e68fca3
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1

--- a/providers/openfeature-ofrep-provider/Gemfile.lock
+++ b/providers/openfeature-ofrep-provider/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       faraday (~> 2.5)
       net-http-persistent (>= 4.0.4, < 5)
     hashdiff (1.2.1)
-    json (2.19.7)
+    json (2.21.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -133,7 +133,7 @@ CHECKSUMS
   faraday-net_http (3.4.3) sha256=9db13becec9312f345a769eeeecf9049c9287d54c0ae053d7235228993a4eec1
   faraday-net_http_persistent (2.3.1) sha256=23ffba37d6a27807a10f033d01918ec958aa73fa6ff0fccfbcd5ce2d2e68fca3
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  json (2.19.7) sha256=fe432c8639f6efff69f9d73b518a3705d9581ab93156f981ea72806e1e5bcc3e
+  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203

--- a/providers/openfeature-optimizely-provider/Gemfile.lock
+++ b/providers/openfeature-optimizely-provider/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     bigdecimal (4.0.1)
     diff-lcs (1.6.2)
     docile (1.4.1)
-    json (2.19.2)
+    json (2.21.1)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
@@ -110,7 +110,7 @@ CHECKSUMS
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
-  json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
+  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
   json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87


### PR DESCRIPTION
## Summary

- Resolved 9 open Dependabot security alerts by bumping vulnerable dependencies across affected provider lockfiles.
- Additionally fixed a pre-existing `simplecov` gemspec/`Gemfile` version conflict in `openfeature-flagsmith-provider` (unrelated to Dependabot, but needed so `bundle install` doesn't fail on this branch after rebasing onto `main`).

## Dependabot Alerts Resolved

| Alert | Package | Manifest | Severity | Fix |
|-------|---------|----------|----------|-----|
| #47 | `faraday` | `providers/openfeature-go-feature-flag-provider/Gemfile.lock` | **high** | Bumped 2.14.2 to 2.14.3 |
| #46 | `faraday` | `providers/openfeature-ofrep-provider/Gemfile.lock` | **high** | Bumped 2.14.2 to 2.14.3 |
| #45 | `faraday` | `providers/openfeature-flagsmith-provider/Gemfile.lock` | **high** | Bumped 2.14.2 to 2.14.3 |
| #41 | `faraday` | `providers/openfeature-go-feature-flag-provider/Gemfile.lock` | **low** | Bumped 2.14.1 to 2.14.3 |
| #40 | `faraday` | `providers/openfeature-ofrep-provider/Gemfile.lock` | **low** | Bumped 2.14.1 to 2.14.3 |
| #39 | `faraday` | `providers/openfeature-flagsmith-provider/Gemfile.lock` | **low** | Bumped 2.14.1 to 2.14.3 |
| #35 | `addressable` | `providers/openfeature-flagsmith-provider/Gemfile.lock` | **high** | Bumped 2.8.9 to 2.9.0 |
| #34 | `addressable` | `providers/openfeature-go-feature-flag-provider/Gemfile.lock` | **high** | Bumped 2.8.7 to 2.9.0 |
| #29 | `json` | `providers/openfeature-meta_provider/Gemfile.lock` | **high** | Bumped 2.19.0 to 2.19.7 |

## Verification

- `bundle exec rspec` and `bundle exec rubocop` pass on each affected provider: go-feature-flag (82 examples), ofrep (44 examples), flagsmith (89 examples), meta_provider (58 examples).