### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/hooks/openfeature-otel-hook/Gemfile.lock
+++ b/hooks/openfeature-otel-hook/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     hana (1.3.7)
-    json (2.21.1)
+    json (2.21.2)
     json_schemer (2.5.0)
       bigdecimal
       hana (~> 1.3)

--- a/providers/openfeature-flagd-provider/Gemfile.lock
+++ b/providers/openfeature-flagd-provider/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     grpc (1.78.1-x86_64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     openfeature-sdk (0.3.1)

--- a/providers/openfeature-flipt-provider/Gemfile.lock
+++ b/providers/openfeature-flipt-provider/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     ffi (1.17.3-x86_64-linux-gnu)
     ffi (1.17.3-x86_64-linux-musl)
     flipt_client (0.10.0)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     openfeature-sdk (0.4.0)

--- a/providers/openfeature-go-feature-flag-provider/Gemfile.lock
+++ b/providers/openfeature-go-feature-flag-provider/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       faraday (~> 2.5)
       net-http-persistent (>= 4.0.4, < 5)
     hashdiff (1.1.1)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)

--- a/providers/openfeature-meta_provider/Gemfile.lock
+++ b/providers/openfeature-meta_provider/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     irb (1.12.0)
       rdoc
       reline (>= 0.4.2)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     openfeature-sdk (0.6.4)

--- a/providers/openfeature-ofrep-provider/Gemfile.lock
+++ b/providers/openfeature-ofrep-provider/Gemfile.lock
@@ -28,7 +28,7 @@ GEM
       faraday (~> 2.5)
       net-http-persistent (>= 4.0.4, < 5)
     hashdiff (1.2.1)
-    json (2.21.1)
+    json (2.21.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -133,7 +133,7 @@ CHECKSUMS
   faraday-net_http (3.4.3) sha256=9db13becec9312f345a769eeeecf9049c9287d54c0ae053d7235228993a4eec1
   faraday-net_http_persistent (2.3.1) sha256=23ffba37d6a27807a10f033d01918ec958aa73fa6ff0fccfbcd5ce2d2e68fca3
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
-  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203

--- a/providers/openfeature-optimizely-provider/Gemfile.lock
+++ b/providers/openfeature-optimizely-provider/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
     bigdecimal (4.0.1)
     diff-lcs (1.6.2)
     docile (1.4.1)
-    json (2.21.1)
+    json (2.21.2)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
@@ -110,7 +110,7 @@ CHECKSUMS
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
-  json (2.21.1) sha256=13a43df75d95641443f5702dff350f237164a9d811ff0f2c2800d4d980220583
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
   json-schema (6.2.0) sha256=e8bff46ed845a22c1ab2bd0d7eccf831c01fe23bb3920caa4c74db4306813666
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87


### PR DESCRIPTION
## Summary

- Resolved 7 open Dependabot security alerts by bumping `json` from 2.21.1 to 2.21.2 across all affected gems

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #66 | `json` | **low** | Bumped to 2.21.2 in `providers/openfeature-optimizely-provider` via `bundle update json` |
| #65 | `json` | **low** | Bumped to 2.21.2 in `providers/openfeature-meta_provider` via `bundle update json` |
| #64 | `json` | **low** | Bumped to 2.21.2 in `providers/openfeature-flipt-provider` via `bundle update json` |
| #63 | `json` | **low** | Bumped to 2.21.2 in `providers/openfeature-go-feature-flag-provider` via `bundle update json` |
| #62 | `json` | **low** | Bumped to 2.21.2 in `providers/openfeature-ofrep-provider` via `bundle update json` |
| #61 | `json` | **low** | Bumped to 2.21.2 in `providers/openfeature-flagd-provider` via `bundle update json` |
| #60 | `json` | **low** | Bumped to 2.21.2 in `hooks/openfeature-otel-hook` via `bundle update json` |